### PR TITLE
Fix CMD and position of the ARG version statement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 ARG jvm_version=11
-ARG version=2.7
 
 FROM gradle:jdk${jvm_version} AS build
 
@@ -14,6 +13,12 @@ RUN ./gradlew bootJar
 
 FROM eclipse-temurin:${jvm_version}-jdk-jammy
 
+# We need this ARG for the CMD.
+# It's defined as an ARG because the CI can't set ENV at build
+ARG version=2.7
+# We instanciate this env variable to be used in CMD
+ENV APP_VERSION="${version}"
+
 RUN adduser --system --no-create-home --disabled-login --group spring-boot
 
 USER spring-boot
@@ -24,7 +29,4 @@ WORKDIR /app
 
 HEALTHCHECK --timeout=1s CMD curl -sSf http://127.0.0.1:8080/actuator/health
 
-# we instanciate this env variable to be used in CMD
-ENV APP_VERSION="${version}"
-
-CMD ["java", "-jar", "sample-app-spring-boot-${APP_VERSION}-0.0.1-SNAPSHOT.jar"]
+CMD ["sh", "-c", "exec java -jar sample-app-spring-boot-${APP_VERSION}-0.0.1-SNAPSHOT.jar"]


### PR DESCRIPTION
There were still issues with the last PR https://github.com/canonical/spring-boot-sample-apps/pull/11.  
Namely, the ARG statement for `version` was not used after the second `FROM` statement (which lead to an empty `APP_VERSION`). And the `CMD` statement didn't had a shell to substitute the env variable in the command.