### PR TITLE
Bugfix/fix liquibase master xml

### DIFF
--- a/spring-boot-2.7-mysql/src/main/resources/liquibase/changelog/00000000000000_initial_schema.xml
+++ b/spring-boot-2.7-mysql/src/main/resources/liquibase/changelog/00000000000000_initial_schema.xml
@@ -10,9 +10,14 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd
                         http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
+    <!--
+    This changeset is required due to an issue with liquibase that doesn't create a primary key for DATABASECHANGELOG table,
+    but mysql-k8s charm is setup with group replication enabled even in standalone deployment, and group replication requires
+    all tables to have primary keys
+    -->
     <changeSet id="00000000000000" author="gschiano">
         <sql dbms="mysql">
-            ALTER TABLE `DATABASECHANGELOG` ADD `id2` INT NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST;
+            ALTER TABLE `DATABASECHANGELOG` ADD `PRIMARY_KEY` INT NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST;
         </sql>
     </changeSet>
     <changeSet id="00000000000001" author="gschiano">

--- a/spring-boot-2.7-mysql/src/main/resources/liquibase/changelog/00000000000000_initial_schema.xml
+++ b/spring-boot-2.7-mysql/src/main/resources/liquibase/changelog/00000000000000_initial_schema.xml
@@ -1,8 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 	Copyright 2023 Canonical Ltd.
 	See LICENSE file for licensing details.
 -->
-<?xml version="1.0" encoding="utf-8"?>
 <databaseChangeLog
     xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
     xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
@@ -10,6 +10,11 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd
                         http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
+    <changeSet id="00000000000000" author="gschiano">
+        <sql dbms="mysql">
+            ALTER TABLE `DATABASECHANGELOG` ADD `id2` INT NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST;
+        </sql>
+    </changeSet>
     <changeSet id="00000000000001" author="gschiano">
         <createTable tableName="user">
             <column name="id" type="bigint" autoIncrement="true">

--- a/spring-boot-2.7-mysql/src/main/resources/liquibase/data/user.csv
+++ b/spring-boot-2.7-mysql/src/main/resources/liquibase/data/user.csv
@@ -1,3 +1,3 @@
-id;login;password_hash;first_name;last_name;email;image_url;activated;lang_key
-1;admin;test;Administrator;Administrator;admin@localhost;;true;en
-2;user;test;User;User;user@localhost;;true;en
+id;login;password_hash;first_name;last_name;email;activated
+1;admin;test;Administrator;Administrator;admin@localhost;true
+2;user;test;User;User;user@localhost;true

--- a/spring-boot-2.7-mysql/src/main/resources/liquibase/master.xml
+++ b/spring-boot-2.7-mysql/src/main/resources/liquibase/master.xml
@@ -1,8 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 	Copyright 2023 Canonical Ltd.
 	See LICENSE file for licensing details.
 -->
-<?xml version="1.0" encoding="utf-8"?>
 <databaseChangeLog
     xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/spring-boot-3.0-mysql/src/main/resources/liquibase/changelog/00000000000000_initial_schema.xml
+++ b/spring-boot-3.0-mysql/src/main/resources/liquibase/changelog/00000000000000_initial_schema.xml
@@ -10,9 +10,14 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
                         http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
+    <!--
+    This changeset is required due to an issue with liquibase that doesn't create a primary key for DATABASECHANGELOG table,
+    but mysql-k8s charm is setup with group replication enabled even in standalone deployment, and group replication requires
+    all tables to have primary keys
+    -->
     <changeSet id="00000000000000" author="gschiano">
         <sql dbms="mysql">
-            ALTER TABLE `DATABASECHANGELOG` ADD `id2` INT NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST;
+            ALTER TABLE `DATABASECHANGELOG` ADD `PRIMARY_KEY` INT NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST;
         </sql>
     </changeSet>
     <changeSet id="00000000000001" author="gschiano">

--- a/spring-boot-3.0-mysql/src/main/resources/liquibase/changelog/00000000000000_initial_schema.xml
+++ b/spring-boot-3.0-mysql/src/main/resources/liquibase/changelog/00000000000000_initial_schema.xml
@@ -1,8 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright 2023 Canonical Ltd.
     See LICENSE file for licensing details.
 -->
-<?xml version="1.0" encoding="utf-8"?>
 <databaseChangeLog
     xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
     xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
@@ -10,6 +10,11 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
                         http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
+    <changeSet id="00000000000000" author="gschiano">
+        <sql dbms="mysql">
+            ALTER TABLE `DATABASECHANGELOG` ADD `id2` INT NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST;
+        </sql>
+    </changeSet>
     <changeSet id="00000000000001" author="gschiano">
         <createTable tableName="user">
             <column name="id" type="bigint" autoIncrement="true">

--- a/spring-boot-3.0-mysql/src/main/resources/liquibase/data/user.csv
+++ b/spring-boot-3.0-mysql/src/main/resources/liquibase/data/user.csv
@@ -1,3 +1,3 @@
-id;login;password_hash;first_name;last_name;email;image_url;activated;lang_key
-1;admin;test;Administrator;Administrator;admin@localhost;;true;en
-2;user;test;User;User;user@localhost;;true;en
+id;login;password_hash;first_name;last_name;email;activated
+1;admin;test;Administrator;Administrator;admin@localhost;true
+2;user;test;User;User;user@localhost;true

--- a/spring-boot-3.0-mysql/src/main/resources/liquibase/master.xml
+++ b/spring-boot-3.0-mysql/src/main/resources/liquibase/master.xml
@@ -1,8 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright 2023 Canonical Ltd.
     See LICENSE file for licensing details.
 -->
-<?xml version="1.0" encoding="utf-8"?>
 <databaseChangeLog
     xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
Fix more issues:
* Liquibase doesn't have primary key in DATABASECHANGELOG table, which is not compatible with the way Mysql charm is deployed (group replication requires primary key for every table)
* user.csv had some extra fields that I forgot to remove
* initial schema still had the XML declaration after the copyright